### PR TITLE
Updated README.textile with correct Guide Link

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -2,5 +2,5 @@ h1. Deadbolt 2 - An authorisation system for Play 2
 
 Deadbolt is a powerful authorisation mechanism for defining access rights to certain controller methods or parts of a view.
 
-For a complete guide, please refer to the deadbolt-2-guide (<https://github.com/schaloner/deadbolt-2-guide>)
+For a complete guide, please refer to the "deadbolt-2-guide (https://github.com/schaloner/deadbolt-2-guide)":https://github.com/schaloner/deadbolt-2-guide
 


### PR DESCRIPTION
Candidate for smallest PR ever but I noticed the link to the guide had the trailing > included in it when clicked and it was nearly as fast fixing it and doing a PR than just tweeting about it.
